### PR TITLE
handle non-top-level display calls

### DIFF
--- a/bin/nodebooks.js
+++ b/bin/nodebooks.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+var fs = require('fs')
+var nodebooks = require('../nodebooks')
+
+var file = process.argv[2]
+console.log( file )
+
+function formatPeek ( peek ) {
+  return peek.results.map( function ( result, i ) {
+    return ( peek.results.length > 1 ? '[' + i + ']: ' : '' ) + JSON.stringify( result )
+  }).join( '\n' ) + '\n\n';
+}
+
+function formatCode ( code ) {
+  return '```js\n' + code.trim() + '\n```\n\n';
+}
+
+var code = fs.readFileSync(file, 'utf-8')
+nodebooks.run(code, function (result) {
+  var lines = code.split('\n');
+  var peeks = []
+
+  // TODO different outputters
+  Object.keys(result).forEach(function (uid) {
+    peeks.push(result[uid]);
+  })
+
+  peeks.sort(function (a, b) {
+    return a.line - b.line;
+  })
+
+  var block = [];
+  var blocks = [];
+  var nextPeek = peeks.shift();
+  var i;
+  for ( i = 0; i < lines.length; i += 1 ) {
+    if ( !nextPeek || i < nextPeek.line ) {
+      block.push( lines[i] );
+    } else {
+      if ( block.length ) {
+        blocks.push( formatCode( block.join('\n') ) );
+        block = [ lines[i] ];
+      }
+
+      blocks.push( formatPeek( nextPeek ) );
+      nextPeek = peeks.shift();
+    }
+  }
+
+  blocks.push( formatCode( block.join( '\n' ) ) )
+
+  console.log( blocks.join( '\n' ).trim() )
+})

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 var io = require('indian-ocean')
 
-var display = require('./nodebooks.js')
 var data = io.readDataSync('data/test.csv')
 
 var numbs = [1,2,3]
 
 display(data)
 display(numbs)
+
+numbs.forEach(function (num) {
+	display(num*num);
+});

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "",
   "main": "index.js",
+  "bin": {
+    "nodebooks": "./bin/nodebooks.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -10,7 +13,9 @@
   "license": "MIT",
   "dependencies": {
     "acorn": "^2.3.0",
+    "estree-walker": "^0.1.3",
     "indian-ocean": "^0.4.0",
+    "magic-string": "^0.6.5",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
- moves execution into a command line executable (`nodebooks my-file.js > result.md` – needs `npm link` in order to work)
- walks AST to discover calls to `display()` not at the top level, insert UIDs, and track call sites
- uses `vm` module to execute code in dedicated context – should make it possible to monkey patch low level async stuff
- some other junk i didn't tidy up yet
